### PR TITLE
Update abaplint.json

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -24,7 +24,7 @@
     }
   ],
   "syntax": {
-    "version": "v740sp08",
+    "version": "v702",
     "errorNamespace": "^(Z|Y)"
   },
   "rules": {


### PR DESCRIPTION
AGS should theoretically be able to run wherever ABAP-Swagger does, so we need to check for 7.02 syntax